### PR TITLE
Create stats.py to display statistical info

### DIFF
--- a/stats.py
+++ b/stats.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+"""This parses data from markdown files in reports directory."""
+
+import re
+from os import listdir
+from os.path import isfile, join
+
+# Set to True to enable print summary lines for each incident
+# False will just display totals by state
+show_summaries = False
+
+# Vars, defaults should be fine
+path = 'reports'
+files = [f for f in listdir(path) if isfile(join(path, f))]
+summary = dict()
+total = 0
+search_term = re.compile('^### .*$')  # Needs to match summary line format.
+
+# Parse data out of markdown files
+for f in files:
+    state = f.strip('.md')
+    state_count = 0
+    with open(f'{path}/{f}') as f:
+        content = f.read().splitlines()
+        matches = list(filter(search_term.match, content))
+        if matches:
+            total += len(matches)  # Add to total
+            summary[state] = list() # store by state
+            for match in matches:
+                if len(match) > 0:
+                    summary[state].append(match.strip('### '))
+
+def print_summaries(lines):
+    """Used to optionally print summary lines"""
+    for line in lines:
+        print(f'    {line}')
+    print('-------------')
+    
+# Display results
+print(f'Total Number of Incidents: {total}')
+for k in sorted(summary.keys()):
+    state_total = len(summary[k])
+    print(f'  {k}: {state_total} incidents')
+
+    # Uncomment below for summary of each incidenta
+    if show_summaries is True:
+        print_summaries(summary[k])


### PR DESCRIPTION
Python3 script to do some basic parsing of markdown files. No external modules or config required. Optionally set show_summaries to True|False to include displaying summary lines with count data.

For PR Review:
Feel free to decline/ignore. I was interested in easily seeing counts and summaries of this data on a repeatable basis (as the repo changes.) This is a Python3 script to do that. It prints out to the console when run. An example of the short output is below. There is configuration that can be modified to include the summary lines with each states totals.

It's pretty rough and assumes only incident summaries use the H3 markdown tag. If you can run Python3 and can use it great, if not no worries. I appreciate the work you are putting in and will help as I can. If there is more in depth data analysis you would like see let me know, I am happy to expand this to be more robust provided some direction is given on relevant data. (Long time dev here.)

Example short output:

Total Number of Incidents: 117
  Alabama: 2 incidents
  Arkansas: 1 incidents
  California: 12 incidents
  Colorado: 6 incidents
  Florida: 1 incidents
  Georgia: 2 incidents
  Illinois: 2 incidents
  Indiana: 6 incidents
  Kansas: 1 incidents
  Kentucky: 5 incidents
  Michigan: 6 incidents
  Minnesota: 12 incidents
  Missouri: 3 incidents
  Nebraska: 2 incidents
  Nevada: 1 incidents
  New York: 13 incidents
  Ohio: 8 incidents
  Oregon: 1 incidents
  Pennsylvania: 7 incidents
  South Carolina: 1 incidents
  Tennessee: 1 incidents
  Texas: 10 incidents
  Unknown Location: 2 incidents
  Utah: 2 incidents
  Virginia: 2 incidents
  Washington: 5 incidents
  Washington DC: 3 incidents