### PR TITLE
Merge Kansas City reports in correct file

### DIFF
--- a/reports/Kansas.md
+++ b/reports/Kansas.md
@@ -1,9 +1,1 @@
-## Kansas City
-
-### Police arrest man, apparently for speaking | Jun 1st
-
-A line of police stand well apart from a crowd of protestors, one of whom is speaking about the police's use of excessive force. Several officers move in to arrest the speaking man, pepper spraying him and others at point-blank range in order to do so. The arrested man is dragged/pushed/falls face down onto the road.
-
-**Links**
-
-* https://twitter.com/weslyinfinity/status/1267321172309544960?
+(no entries yet)

--- a/reports/Missouri.md
+++ b/reports/Missouri.md
@@ -13,9 +13,10 @@ Video shows the police tear gassing an entire park, including one baby in Kansas
 
 * https://old.reddit.com/r/PublicFreakout/comments/guswxo/he_wasnt_even_addressing_the_police/
 
-### Police pull protester out of crowd to the ground, and teargas nearby protestors | June 1st
+### Police arrest man for speaking and teargas nearby protestors | June 1st
 
-Video shows multiple police pulling a man out of a crowd, teargas nearby protestors, and pin the man to the floor. 
+A line of police stand well apart from a crowd of protestors, one of whom is speaking about the police's use of excessive force. Several officers move in to arrest the speaking man, pepper spraying him and others at point-blank range. The arrested man is dragged/pushed/falls face down onto the road and is pinned there by police.
 
 **Links**
-* https://twitter.com/weslyinfinity/status/1267321172309544960 
+
+* https://twitter.com/weslyinfinity/status/1267321172309544960?


### PR DESCRIPTION
I mistakenly added an incident from Kansas City to `Kansas.md` when it should have been in `Missouri.md`. This PR merges that wrongly-placed report with the existing correct one and removes it from the Kansas file (which is empty for now).

Fixes #168 