### PR TITLE
Added event to Kalamazoo

### DIFF
--- a/reports/Michigan.md
+++ b/reports/Michigan.md
@@ -64,3 +64,5 @@ A crowd of peaceful protesters downtown refused to disperse upon curfew taking e
 
 * WOODTV8 live crew: https://streamable.com/xvlky1
 * Kalamazoo Gazette via Facebook Live: https://streamable.com/0wfiu3
+* MLive article: https://www.mlive.com/news/kalamazoo/2020/06/my-heart-was-wrenched-with-pain-assistant-chief-says-of-ordering-tear-gas-on-protesters.html
+* IBB image backup of Asst. Chief and City Manager kneeling: https://ibb.co/Fgrwqkj

--- a/reports/Michigan.md
+++ b/reports/Michigan.md
@@ -58,7 +58,7 @@ A group of protesters lie on the ground with arms outstretched in front of a gro
 
 ### Police fire tear gas at peaceful protesters | June 2nd ~7:30pm EDT
 
-A crowd of peaceful protesters downtown refused to disperse upon curfew taking effect. Assistant Police Chief Vernon Coakley knelt with protest organizers momentarily for a photo op before standing up and ordering the crowd tear gassed over a radio. A protester in a tie-die shirt kicked tear gas away from a fellow kneeling protester, and was then arrested by police against a National Guard humvee.
+A crowd of peaceful protesters downtown refused to disperse upon curfew taking effect. A protester in a tie-die shirt kicked tear gas away from a fellow kneeling protester, and was then arrested by police against a National Guard humvee.
 
 **Links**
 

--- a/reports/Michigan.md
+++ b/reports/Michigan.md
@@ -55,3 +55,12 @@ A group of protesters lie on the ground with arms outstretched in front of a gro
 
 * https://twitter.com/i/status/1267677463850745858
 * Source, at 33:40  https://www.facebook.com/BlaineBurnett11/videos/963503949886/
+
+### Police fire tear gas at peaceful protesters | June 2nd ~7:30pm EDT
+
+A crowd of peaceful protesters downtown refused to disperse upon curfew taking effect. Assistant Police Chief Vernon Coakley knelt with protest organizers momentarily for a photo op before standing up and ordering the crowd tear gassed over a radio. A protester in a tie-die shirt kicked tear gas away from a fellow kneeling protester, and was then arrested by police against a National Guard humvee.
+
+**Links**
+
+* WOODTV8 live crew: https://streamable.com/xvlky1
+* Kalamazoo Gazette via Facebook Live: https://streamable.com/0wfiu3


### PR DESCRIPTION
Added event to Michigan - Kalamazoo: curfew enforcement downtown on June 2nd. Two videos from local news live feeds recorded that night. Cops deployed tear gas against a peaceful crowd.