### PR TITLE
Add template for Incident report issues on this repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/incident-report.md
+++ b/.github/ISSUE_TEMPLATE/incident-report.md
@@ -7,7 +7,11 @@ assignees: ''
 
 ---
 
-Instructions: Add the key information about the incident under the headings (Location, Date, etc.) below and then click the green "Submit new issue" button. If you are unsure about any details then just write "Unknown" under that heading.
+INSTRUCTIONS: Add the key information about the incident under the headings Location, Date, Description and Links below and then click the green "Submit new issue" button.
+
+If you are unsure about any details then please write "Unknown" under that heading.
+
+---
 
 ## Location
 
@@ -21,6 +25,6 @@ e.g. June 3rd
 
 e.g. Police pepper spray kneeling protestors
 
-## Link(s)
+## Links
 
 e.g. https://www.reddit.com/r/.../...

--- a/.github/ISSUE_TEMPLATE/incident-report.md
+++ b/.github/ISSUE_TEMPLATE/incident-report.md
@@ -1,0 +1,24 @@
+---
+name: Incident report
+about: Report a new incident that should be added to the database
+title: Incident in CITY, STATE
+labels: Incident report
+assignees: ''
+
+---
+
+## Location
+
+*e.g. Compton, California (also include this in the title field above)*
+
+## Date
+
+*e.g. June 3rd*
+
+## Description
+
+*Please provide a brief description of the incident here*
+
+## Link(s)
+
+*List links to videos or other resources here*

--- a/.github/ISSUE_TEMPLATE/incident-report.md
+++ b/.github/ISSUE_TEMPLATE/incident-report.md
@@ -7,18 +7,20 @@ assignees: ''
 
 ---
 
+Instructions: Add the key information about the incident under the headings (Location, Date, etc.) below and then click the green "Submit new issue" button. If you are unsure about any details then just write "Unknown" under that heading.
+
 ## Location
 
-*e.g. Compton, California (also include this in the title field above)*
+e.g. Compton, California (also include this in the title field above)
 
 ## Date
 
-*e.g. June 3rd*
+e.g. June 3rd
 
 ## Description
 
-*Please provide a brief description of the incident here*
+e.g. Police pepper spray kneeling protestors
 
 ## Link(s)
 
-*List links to videos or other resources here*
+e.g. https://www.reddit.com/r/.../...


### PR DESCRIPTION
I've followed up on what I suggested in #35, read [the GitHub docs](https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository) and have created this custom template for "Incident report" issues.

**If this PR is accepted then it will** make it so that the "New issue" button
<img width="128" alt="image" src="https://user-images.githubusercontent.com/951849/83684440-edd98600-a5de-11ea-86b8-b216cbc1d38c.png">
no longer takes the user straight to a blank issue form, but instead to this page:
<img width="952" alt="image" src="https://user-images.githubusercontent.com/951849/83684497-08abfa80-a5df-11ea-96ad-e8489c7e24db.png">
and then if they click that "Get started" button they will get a nice template for fill in that looks like this:
<img width="1043" alt="image" src="https://user-images.githubusercontent.com/951849/83684612-3db84d00-a5df-11ea-80ed-1677c3839052.png">

As you can see a label can be automatically applied to these issues so they can be filtered and quickly processed and added to the files as PRs by more Git-savvy contributors.

This is linked to #101 and is a very low-tech (but quick) version of #76 