### PR TITLE
Fix Rochester Spelling

### DIFF
--- a/reports/New York.md
+++ b/reports/New York.md
@@ -1,5 +1,5 @@
 
-## Rochestor
+## Rochester
 
 ### Police shoot at people filming | May 31st
 


### PR DESCRIPTION
Moving "Rochestor" to "Rochester"