### PR TITLE
Added 3 links/sources to June 1st Philadelphia Highway Incident

### DIFF
--- a/reports/Pennsylvania.md
+++ b/reports/Pennsylvania.md
@@ -57,7 +57,7 @@ Over 30 protesters are standing in the grassy area beside a highway. Police on t
 * https://www.reddit.com/r/PublicFreakout/comments/guve5f/philadelphia_police_traps_protesters_on_highway/
 * https://twitter.com/bbcease/status/1267582823428501508
 * https://www.youtube.com/watch?v=cXzWicPCNQg
-* https://youtu.be/oCVe8mXOU94
+* [Aerial footage](https://youtu.be/oCVe8mXOU94)
 * https://vimeo.com/425235774
 * https://youtu.be/srC5l--cn14
 

--- a/reports/Pennsylvania.md
+++ b/reports/Pennsylvania.md
@@ -57,6 +57,9 @@ Over 30 protesters are standing in the grassy area beside a highway. Police on t
 * https://www.reddit.com/r/PublicFreakout/comments/guve5f/philadelphia_police_traps_protesters_on_highway/
 * https://twitter.com/bbcease/status/1267582823428501508
 * https://www.youtube.com/watch?v=cXzWicPCNQg
+* https://youtu.be/oCVe8mXOU94
+* https://vimeo.com/425235774
+* https://youtu.be/srC5l--cn14
 
 ### Police officer pepper-sprays three people on their knees | believed to be June 1st
 


### PR DESCRIPTION
* https://youtu.be/oCVe8mXOU94 - This video features helicopter footage of the entire incident

* https://vimeo.com/425235774 - This video is from the ground, before the protesters were gassed up onto the hill. The individual holding the camera states they are press, and an officer proceeds to spray mace at them. 

* https://youtu.be/srC5l--cn14 - This video is a first hand account of the event, features a narrative of their experience along with spliced footage from sources above.