### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Order is important; the last matching pattern takes the most precedence
+
+# ubershmekel owns the files related to the data_builder script, but not the files in the downloader directory
+tools/*     @ubershmekel

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,4 @@
 
 # ubershmekel owns the files related to the data_builder script, but not the files in the downloader directory
 tools/*     @ubershmekel
+tools/downloader/ @bonedaddy 


### PR DESCRIPTION
Add a CODEOWNERS file with @ubershmekel as owner of the data_builder tool. When a file that has an owner is modified in a pull request, Github will automatically request the owner(s) as reviewers. This could be extended to other files if necessary.

Note: I haven't used this feature before, but I think it could be useful.