### PR TITLE
Fix typo in `Washington DC.md`

### DIFF
--- a/reports/Washington DC.md
+++ b/reports/Washington DC.md
@@ -69,7 +69,7 @@ A DC resident discusses being accosted by officers when trying to enter his home
 * https://twitter.com/suckmyunicornD/status/1267767217392934917
 * https://dcist.com/story/20/06/02/dupont-dc-home-protest-rahul-dubey/
 
-#### Police charge peaceful crowd, beat them with shields |
+### Police charge peaceful crowd, beat them with shields |
 
 Here, police are captured charging into a crowd of peaceful protestors and hitting them with their shields. One individual can be seen bleeding from the mouth after being struck, before being pushed to the ground.
 


### PR DESCRIPTION
There was an extra `#` in the header for the last entry in the file, which caused it to show up in the JSON with no title.