### PR TITLE
Added Link - Minneapolis, MN - Police slashes tire

### DIFF
--- a/reports/Minnesota.md
+++ b/reports/Minnesota.md
@@ -129,6 +129,7 @@ id: mn-minneapolis-8
 * https://twitter.com/val_ebertz/status/1266975058230235137
 * https://twitter.com/andrewkimmel/status/1266987126467461120?s=20
 * https://twitter.com/andrewkimmel/status/1267012840197586946?s=20
+* https://www.motherjones.com/anti-racism-police-protest/2020/06/videos-show-cops-slashing-car-tires-at-protests-in-minneapolis/
 
 ### CBS news crew shot with rubber bullets | May 31st
 


### PR DESCRIPTION
Added link to the Mother Jones article on the incident involving police slashing tires on May 31st