### PR TITLE
Add links for or-portland-7

### DIFF
--- a/reports/Oregon.md
+++ b/reports/Oregon.md
@@ -74,4 +74,6 @@ id: or-portland-7
 
 **Links**
 
-*  https://twitter.com/chadloder/status/1269526243138928642
+* https://twitter.com/chadloder/status/1269526243138928642
+* https://twitter.com/TVAyyyy/status/1269526590456643584
+* https://twitter.com/DonovanFarley/status/1269701897377603584


### PR DESCRIPTION
Closes #430 
Note: the issue linked says June 7th, the existing incident says June 6th. The twitter videos were both posted around 1am on the 7th, so it could go either way. I'm leaving it as the 6th for now.