### PR TITLE
Removing redundant incident from Minnesota.md

### DIFF
--- a/reports/Minnesota.md
+++ b/reports/Minnesota.md
@@ -6,7 +6,7 @@
 
 A group of cops start to approach a group of press taking photos and video. One press member repeats "we have our hands up and we have press passes". An officer walking by points in the direction of a photographer and says something indiscernable. The camera pans to show a cop hitting the photographer in the neck and head with a wooden baton.
 
-id: mn-minneapolis-22
+id: mn-minneapolis-21
 
 **Links**
 
@@ -43,7 +43,7 @@ id: mn-minneapolis-1
 
 The Awaijane family who owned a gas station had family and friends protecting their property from looters, when police arrived they were told to go inside. The family complied and the event was followed by police shooting rubber bullets and tear gas in to the gas station.
 
-id: mn-minneapolis-21
+id: mn-minneapolis-20
 
 **Links**
 
@@ -95,22 +95,11 @@ id: mn-minneapolis-15
 * https://mobile.twitter.com/chadloder/status/1266962631887224837
 
 
-### Police shoot rubber bullets and teargas at an MSNBC reporter | believed to be May 30th
-
-Police shoot rubber bullets and teargas at a reporter and his crew, as they're broadcasting live on-air, while retreating from the police line.
-
-id: mn-minneapolis-16
-
-**Links**
-
-* https://twitter.com/greg_doucette/status/1267118696960528386
-
-
 ### Swiss journalists shot at with rubber bullets by police | May 30th
 
 In the video, police can be seen in the distance and shots towards the camera can be heard. According to news reports, journalist Gaspard Kühn stated that the journalists showed press passes and called out that they were journalists, asking for safe passage. Police told the men to “back up” and then shot rubber bullets at them.
 
-id: mn-minneapolis-17
+id: mn-minneapolis-16
 
 **Links**
 
@@ -231,7 +220,7 @@ id: mn-minneapolis-13
 
 Police responding to a medical emergency – a tanker truck deliberately running over protestors – slow down to pepperspray folks from their SUV. Location: I-35W I-94. Some car numbers involved: first spraying (0:08 in first video) is car 30? (cannot make out last digit), second spraying (0:13 in first video) is car 352, third spraying (0:20 at camera) is car 830.
 
-id: mn-minneapolis-18
+id: mn-minneapolis-17
 
 **Links**
 
@@ -242,7 +231,7 @@ id: mn-minneapolis-18
 
 A PCA who was treating someone with a rubber bullet wound reports that officers approached the nurses' tent and opened fire with rubber bullets.
 
-id: mn-minneapolis-19
+id: mn-minneapolis-18
 
 **Links**
 
@@ -253,7 +242,7 @@ id: mn-minneapolis-19
 
 South Minneapolis outside 5th Precinct. Group of journalists "were hit with pepper spray, concussion grenades, batons, and tear gas by Minnesota State Patrol"
 
-id: mn-minneapolis-20
+id: mn-minneapolis-19
 
 **Links**
 


### PR DESCRIPTION
Minneapolis-15 and 16 are the same incident, but it appears that since MSNBC was broadcasting a CNN crew it got confused as two separate incidents. Removed #16 and updated incident #'s following it.