### PR TITLE
Remove dead link from mn-minneapolis-16

### DIFF
--- a/reports/Minnesota.md
+++ b/reports/Minnesota.md
@@ -133,7 +133,6 @@ id: mn-minneapolis-16
 
 * [Video](https://www.srf.ch/play/tv/news-clip/video/schweizer-journalisten-werden-mit-gummischrot-attackiert?id=67d44dd8-f16e-4db0-b690-799ab827956a&startTime=9)
 * [German-language news article](https://www.srf.ch/news/international/pressefreiheit-unter-beschuss-schweizer-journalisten-in-den-usa-von-polizei-attackiert)
-* [English-language news article](https://www.swissinfo.ch/eng/minneapolis-protests-_rubber-bullets-shot-at-swiss-journalists-by-us-police-/45808806)
 
 
 ### Camera man shot by police | May 30th


### PR DESCRIPTION
This link was redirecting to a rather nice but wholly irrelevant picture of the Caribbean:

`https://www.swissinfo.ch/eng/minneapolis-protests-_rubber-bullets-shot-at-swiss-journalists-by-us-police-/45808806` :point_down: 

 ![The picture of the Carribean](https://www.swissinfo.ch/resource/blob/45809478/f6ea7cd9efe49f8e6f43291dee691218/cumuluscaribbean_row7005071560_1920x1080-data.jpg)

Fixes #631 