### PR TITLE
Added Black and Flake8 including workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+name: Lint
+
+on:
+  push:
+    # Only run if:
+    paths:
+      # Changes in python, yml(github actions), pyproject.toml(black config),
+      # .flake8(flake8 config)
+      - "**.py"
+      - "**.yml"
+      - "**/pyproject.toml"
+      - "**/.flake8"
+
+jobs:
+  lint-python:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r tools/requirements.txt
+
+    - name: Run black
+      run: black --check --diff .
+      working-directory: tools
+
+    - name: Run flake8
+      run: flake8 .
+      working-directory: tools

--- a/tools/.flake8
+++ b/tools/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+exclude =
+    data_build,
+    downloader

--- a/tools/README.md
+++ b/tools/README.md
@@ -17,11 +17,32 @@ pip install -r requirements.txt
 python tools/data_builder.py
 ```
 
+## Style/Syntax
+
+Reformat Python files using [psf/black](https://github.com/psf/black): The
+ uncompromising Python code formatter:
+
+```bash
+black .
+```
+
+Python Black is included in `requirements.txt`, however based on your method of
+installation, the `black` command may not be in your path. Adjust the command
+accordingly.
+
+Test Python files syntax using [Flake8](https://flake8.pycqa.org/en/latest/):
+Your Tool For Style Guide Enforcement:
+
+```bash
+flake8 .
+```
+
 ## Tests
 
 Tests use the [pytest](https://docs.pytest.org/) framework
 
 ### Adding tests
+
 - For getting started with Pytest, see [official docs](https://docs.pytest.org/en/stable/getting-started.html)
 - Prefix test names with `test_`
 - All test names must be unique

--- a/tools/data_builder.py
+++ b/tools/data_builder.py
@@ -10,14 +10,14 @@ from datetime import datetime, timezone
 
 # `or '.'` because when you're in the same directory as this code
 # `ValueError: no path specified` gets thrown by `relpath` with empty input
-src_dir = os.path.relpath(os.path.dirname(__file__) or '.')
-md_dir = os.path.join(src_dir, '..', 'reports')
-out_dir = os.path.join(src_dir, 'data_build')
+src_dir = os.path.relpath(os.path.dirname(__file__) or ".")
+md_dir = os.path.join(src_dir, "..", "reports")
+out_dir = os.path.join(src_dir, "data_build")
 combined_fpath = os.path.join(out_dir, "all-locations.md")
-csv_fpath_v1 = os.path.join(out_dir, 'all-locations.csv')
-json_fpath_v1 = os.path.join(out_dir, 'all-locations.json')
-json_fpath_v2 = os.path.join(out_dir, 'all-locations-v2.json')
-readme_fpath = os.path.join(out_dir, 'README.md')
+csv_fpath_v1 = os.path.join(out_dir, "all-locations.csv")
+json_fpath_v1 = os.path.join(out_dir, "all-locations.json")
+json_fpath_v2 = os.path.join(out_dir, "all-locations-v2.json")
+readme_fpath = os.path.join(out_dir, "README.md")
 
 if not os.path.exists(out_dir):
     os.mkdir(out_dir)
@@ -25,29 +25,33 @@ if not os.path.exists(out_dir):
 date_regex = re.compile(
     r"(Jan(uary)?|Feb(ruary)?|Mar(ch)?|Apr(il)?|May|Jun(e)?|"
     r"Jul(y)?|Aug(ust)?|Sep(tember)?|Oct(ober)?|Nov(ember)?|"
-    r"Dec(ember)?)\s+\d{1,2}")
+    r"Dec(ember)?)\s+\d{1,2}"
+)
 
 url_regex = re.compile(
     r"(http|ftp|https):\/\/([\w\-_]+(?:(?:\.[\w\-_]+)+))"
-    r"([\w\-\.,@?^=%&amp;:/~\+#\!]*[\w\-\@?^=%&amp;/~\+#\!])?")
+    r"([\w\-\.,@?^=%&amp;:/~\+#\!]*[\w\-\@?^=%&amp;/~\+#\!])?"
+)
 
 
 def title_to_name_date(line):
-    parts = line.split('|')
+    parts = line.split("|")
     name = parts[0].strip()
     if len(parts) == 1:
         print(f"Failed date parse: missing date for {line}")
-        return line.strip(), '', ''
+        return line.strip(), "", ""
     if len(name) == 0:
         print(f"Failed name parse: missing name for {line}")
     date_text = parts[1].strip()
 
     try:
         date_found = date_regex.search(date_text).group()
-        date = parse(date_found).strftime('%Y-%m-%d')
+        date = parse(date_found).strftime("%Y-%m-%d")
     except (ValueError, AttributeError) as err:
-        print(f"Failed date format parse for title '{name}' and date '{date_text}': {err}")
-        date = ''
+        print(
+            f"Failed date format parse for title '{name}' and date '{date_text}': {err}"
+        )
+        date = ""
     return name, date, date_text
 
 
@@ -58,18 +62,20 @@ def critical_exit(msg):
 
 def read_all_md_files(base_dir):
     md_texts = {}
-    for md_file in glob.glob(base_dir + '/*.md'):
+    for md_file in glob.glob(base_dir + "/*.md"):
         print(f"Reading '{os.path.basename(md_file)}'")
-        with open(md_file, 'rb') as fin:
+        with open(md_file, "rb") as fin:
             fname = os.path.basename(md_file)
-            state_name = fname.replace('.md', '')
-            md_texts[state_name] = fin.read().decode('utf-8')
+            state_name = fname.replace(".md", "")
+            md_texts[state_name] = fin.read().decode("utf-8")
     print(f"Got {len(md_texts)} locations")
     return md_texts
+
 
 def finalize_entry(entry):
     entry["description"] = entry["description"].strip()
     return entry
+
 
 def find_md_link_or_url(text):
     """
@@ -78,50 +84,51 @@ def find_md_link_or_url(text):
     
     All the text goes into the text, and the URL as well.
     """
-    start = 0,
-    open_sq = 1,
-    closed_sq = 2,
-    open_curve = 3,
-    closed_curve = 4,
+    start = (0,)
+    open_sq = (1,)
+    closed_sq = (2,)
+    open_curve = (3,)
+    closed_curve = (4,)
     state = start
-    text_text = ''
-    link_url = ''
+    text_text = ""
+    link_url = ""
     for ch in text:
         if state == start:
-            if ch == '[':
+            if ch == "[":
                 state = open_sq
             else:
                 text_text += ch
         elif state == open_sq:
-            if ch == ']':
+            if ch == "]":
                 state = closed_sq
             else:
                 text_text += ch
         elif state == closed_sq:
-            if ch == '(':
+            if ch == "(":
                 state = open_curve
         elif state == open_curve:
-            if ch == ')':
+            if ch == ")":
                 state == closed_curve
             else:
                 link_url += ch
         elif state == closed_curve:
             text_text += ch
-    
+
     if len(link_url) == 0:
         # no markdown link found, consider it all one url
         link_url = text_text
-        text_text = ''
+        text_text = ""
 
     return text_text.strip(), link_url.strip()
 
+
 def parse_state(state, text):
     source_link = f"https://github.com/2020PB/police-brutality/blob/master/reports/{state}.md"
-    city = ''
-    if state == 'Washington DC':
-        city = 'DC'
-    if state == 'Unknown Location':
-        city = ''
+    city = ""
+    if state == "Washington DC":
+        city = "DC"
+    if state == "Unknown Location":
+        city = ""
 
     clean_entry = {
         "links": [],
@@ -140,14 +147,14 @@ def parse_state(state, text):
         # if len(line) < 2:
         #     continue
 
-        starts_with = ''
+        starts_with = ""
         for char in line:
-            if char in ('*', '#', '-'):
+            if char in ("*", "#", "-"):
                 starts_with += char
             else:
                 break
 
-        if entry["links"] and '#' in starts_with:
+        if entry["links"] and "#" in starts_with:
             # We found a new city name so we must finish this `entry`
             # and start a fresh new one
             # Let the outer loop have this completed entry
@@ -159,48 +166,47 @@ def parse_state(state, text):
             entry["city"] = city
 
         # remove the prefix
-        line = line[len(starts_with):].strip()
+        line = line[len(starts_with) :].strip()
 
-        if starts_with == '##':
+        if starts_with == "##":
             city = line
             entry["city"] = city
-        elif starts_with == '###':
+        elif starts_with == "###":
             name, date, date_text = title_to_name_date(line)
             # print(name, date)
             entry["name"] = name
             entry["date"] = date
             entry["date_text"] = date_text
-        elif starts_with == '*':
+        elif starts_with == "*":
             link_text, link_url = find_md_link_or_url(line)
             if link_url:
                 entry["links"].append(link_url)
-                entry["links_v2"].append({
-                    "url": link_url,
-                    "text": link_text,
-                })
+                entry["links_v2"].append(
+                    {"url": link_url, "text": link_text,}
+                )
             else:
                 print("Data build failed, exiting")
                 critical_exit(f"Failed link parse '{line}' in state '{state}'")
-        elif starts_with == '**':
+        elif starts_with == "**":
             # **links** line
             pass
         else:
             # Text without a markdown marker, this might be the description or metadata
-            id_prefix = 'id:'
-            tags_prefix = 'tags:'
+            id_prefix = "id:"
+            tags_prefix = "tags:"
             if line.startswith(id_prefix):
-                entry["id"] = line[len(id_prefix):].strip()
+                entry["id"] = line[len(id_prefix) :].strip()
             elif line.startswith(tags_prefix):
-                spacey_tags = line[len(tags_prefix):].split(',')
+                spacey_tags = line[len(tags_prefix) :].split(",")
                 entry["tags"] = [tag.strip() for tag in spacey_tags]
             else:
                 # Add a line to the description, but make sure there are no extra
                 # new lines surrounding it.
-                #entry["description"] = (entry["description"] + '\n' + line).strip()
+                # entry["description"] = (entry["description"] + '\n' + line).strip()
                 # We want to allow as many newlines as are already in the middle of the description
                 # but not allow any extra newlines in the end or beginning. The only way
                 # to do that right now is right before we `yield`
-                entry["description"] += line + '\n'
+                entry["description"] += line + "\n"
 
     if entry and entry["links"]:
         yield finalize_entry(entry)
@@ -215,29 +221,30 @@ def process_md_texts(md_texts):
             data.append(entry)
     return data
 
+
 updated_at = datetime.now(timezone.utc).isoformat()
 
-md_header = f'''
+md_header = f"""
 GENERATED FILE, PLEASE MAKE EDITS ON MASTER AT https://github.com/2020PB/police-brutality/
 
 UPDATED AT: {updated_at}
 
-'''
+"""
 
-md_out_format = '''
+md_out_format = """
 # {location}
 
 {text}
 
-'''
+"""
 
 
 def to_merged_md_file(md_texts, target_path):
-    with open(target_path, 'wb') as fout:
+    with open(target_path, "wb") as fout:
         fout.write(md_header.encode("utf-8"))
         for location, text in sorted(md_texts.items()):
             out_text = md_out_format.format(location=location, text=text)
-            fout.write(out_text.encode('utf-8'))
+            fout.write(out_text.encode("utf-8"))
     print(f"Written merged .md data to {target_path}")
 
 
@@ -251,13 +258,13 @@ def to_csv_file_v1(data, target_path):
         links = flat_row["links"]
         del flat_row["links"]
         for i in range(max_link_count):
-            url = ''
+            url = ""
             if i < len(links):
                 url = links[i]
             flat_row[f"Link {i + 1}"] = url
         flat_data.append(flat_row)
 
-    with open(target_path, 'w', newline='', encoding='utf-8') as fout:
+    with open(target_path, "w", newline="", encoding="utf-8") as fout:
         writer = csv.DictWriter(fout, flat_data[0].keys())
         writer.writeheader()
         writer.writerows(flat_data)
@@ -270,17 +277,19 @@ def to_json_file_v1(data, target_path):
         "edit_at": "https://github.com/2020PB/police-brutality",
         "help": "ask @ubershmekel on twitter",
         "updated_at": updated_at,
-        "data": data
+        "data": data,
     }
-    with open(target_path, 'w') as f:
+    with open(target_path, "w") as f:
         json.dump(data_with_meta, f)
     print(f"Written .json data to {target_path}")
 
+
 def v2_only(item):
     item = copy.deepcopy(item)
-    item['links'] = item['links_v2']
-    del item['links_v2']
+    item["links"] = item["links_v2"]
+    del item["links_v2"]
     return item
+
 
 def to_json_file_v2(data, target_path):
     v2_data = [v2_only(item) for item in data]
@@ -288,14 +297,14 @@ def to_json_file_v2(data, target_path):
         "edit_at": "https://github.com/2020PB/police-brutality",
         "help": "ask @ubershmekel on twitter",
         "updated_at": updated_at,
-        "data": v2_data
+        "data": v2_data,
     }
-    with open(target_path, 'w') as f:
+    with open(target_path, "w") as f:
         json.dump(data_with_meta, f)
     print(f"Written .json v2 data to {target_path}")
 
 
-readme_text ='''
+readme_text = """
 # /r/2020PoliceBrutality/ dataset
 
 This repository exists to accumulate and contextualize evidence of police brutality during the 2020 George Floyd protests.
@@ -314,21 +323,35 @@ Our goal in doing this is to assist journalists, politicians, prosecutors, activ
 * Please edit the `.md` files on the `master` branch at https://github.com/2020PB/police-brutality
 * Also notice each data row has a `edit_at` link so you can find the source data for every entry.
 
-'''
+"""
+
 
 def to_readme(target_path):
-    with open(target_path, 'w') as f:
+    with open(target_path, "w") as f:
         f.write(readme_text)
+
 
 def read_all_data():
     md_texts = read_all_md_files(md_dir)
     data = process_md_texts(md_texts)
     return data
 
+
 def v1_only(item):
     # Deepcopy to avoid affecting the original data
     item = copy.deepcopy(item)
-    v1_keys = set(['links', 'state', 'city', 'edit_at', 'name', 'date', 'date_text', 'id'])
+    v1_keys = set(
+        [
+            "links",
+            "state",
+            "city",
+            "edit_at",
+            "name",
+            "date",
+            "date_text",
+            "id",
+        ]
+    )
     # Cache keys to avoid errors for deleting while iterating
     item_keys = list(item.keys())
     for key in item_keys:
@@ -337,8 +360,7 @@ def v1_only(item):
     return item
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     md_texts = read_all_md_files(md_dir)
     data = process_md_texts(md_texts)
     to_merged_md_file(md_texts, combined_fpath)

--- a/tools/data_builder.py
+++ b/tools/data_builder.py
@@ -49,7 +49,8 @@ def title_to_name_date(line):
         date = parse(date_found).strftime("%Y-%m-%d")
     except (ValueError, AttributeError) as err:
         print(
-            f"Failed date format parse for title '{name}' and date '{date_text}': {err}"
+            f"Failed date format parse for title '{name}' and date"
+            f" '{date_text}': {err}"
         )
         date = ""
     return name, date, date_text
@@ -81,7 +82,7 @@ def find_md_link_or_url(text):
     """
     find_md_link_or_url('ab[cd](ef)xy') returns:
         ('abcdxy', 'ef')
-    
+
     All the text goes into the text, and the URL as well.
     """
     start = (0,)
@@ -123,7 +124,10 @@ def find_md_link_or_url(text):
 
 
 def parse_state(state, text):
-    source_link = f"https://github.com/2020PB/police-brutality/blob/master/reports/{state}.md"
+    source_link = (
+        "https://github.com/2020PB/police-brutality/blob/master"
+        f"/reports/{state}.md"
+    )
     city = ""
     if state == "Washington DC":
         city = "DC"
@@ -166,7 +170,7 @@ def parse_state(state, text):
             entry["city"] = city
 
         # remove the prefix
-        line = line[len(starts_with) :].strip()
+        line = line[len(starts_with) :].strip()  # noqa: E203
 
         if starts_with == "##":
             city = line
@@ -181,9 +185,7 @@ def parse_state(state, text):
             link_text, link_url = find_md_link_or_url(line)
             if link_url:
                 entry["links"].append(link_url)
-                entry["links_v2"].append(
-                    {"url": link_url, "text": link_text,}
-                )
+                entry["links_v2"].append({"url": link_url, "text": link_text})
             else:
                 print("Data build failed, exiting")
                 critical_exit(f"Failed link parse '{line}' in state '{state}'")
@@ -191,21 +193,25 @@ def parse_state(state, text):
             # **links** line
             pass
         else:
-            # Text without a markdown marker, this might be the description or metadata
+            # Text without a markdown marker, this might be the description or
+            # metadata
             id_prefix = "id:"
             tags_prefix = "tags:"
             if line.startswith(id_prefix):
-                entry["id"] = line[len(id_prefix) :].strip()
+                entry["id"] = line[len(id_prefix) :].strip()  # noqa: E203
             elif line.startswith(tags_prefix):
-                spacey_tags = line[len(tags_prefix) :].split(",")
+                spacey_tags = line[len(tags_prefix) :].split(",")  # noqa: E203
                 entry["tags"] = [tag.strip() for tag in spacey_tags]
             else:
-                # Add a line to the description, but make sure there are no extra
-                # new lines surrounding it.
-                # entry["description"] = (entry["description"] + '\n' + line).strip()
-                # We want to allow as many newlines as are already in the middle of the description
-                # but not allow any extra newlines in the end or beginning. The only way
-                # to do that right now is right before we `yield`
+                # Add a line to the description, but make sure there are no
+                # extra new lines surrounding it.
+                # entry["description"] = (
+                #    entry["description"] + "\n" + line
+                # ).strip()
+                # We want to allow as many newlines as are already in the
+                # middle of the description but not allow any extra newlines in
+                # the end or beginning. The only way to do that right now is
+                # right before we `yield`
                 entry["description"] += line + "\n"
 
     if entry and entry["links"]:
@@ -225,7 +231,8 @@ def process_md_texts(md_texts):
 updated_at = datetime.now(timezone.utc).isoformat()
 
 md_header = f"""
-GENERATED FILE, PLEASE MAKE EDITS ON MASTER AT https://github.com/2020PB/police-brutality/
+GENERATED FILE, PLEASE MAKE EDITS ON MASTER AT \
+https://github.com/2020PB/police-brutality/
 
 UPDATED AT: {updated_at}
 
@@ -307,21 +314,30 @@ def to_json_file_v2(data, target_path):
 readme_text = """
 # /r/2020PoliceBrutality/ dataset
 
-This repository exists to accumulate and contextualize evidence of police brutality during the 2020 George Floyd protests.
+This repository exists to accumulate and contextualize evidence of police
+brutality during the 2020 George Floyd protests.
 
-Our goal in doing this is to assist journalists, politicians, prosecutors, activists and concerned citizens who can use the evidence accumulated here for political campaigns, news reporting, public education and prosecution of criminal police officers.
+Our goal in doing this is to assist journalists, politicians, prosecutors,
+activists and concerned citizens who can use the evidence accumulated here for
+political campaigns, news reporting, public education and prosecution of
+criminal police officers.
 
-* This branch is just the files generated by parsing the markdown for ease of building other sites.
-* For example your webapp can query and display data from https://raw.githubusercontent.com/2020PB/police-brutality/data_build/all-locations.json
+* This branch is just the files generated by parsing the markdown for ease of
+  building other sites.
+* For example your webapp can query and display data from
+  https://raw.githubusercontent.com/2020PB/police-brutality/data_build/all-locations.json
 * For more info see https://github.com/2020PB/police-brutality
-* These data files are generated by https://github.com/2020PB/police-brutality/tree/master/tools
+* These data files are generated by
+  https://github.com/2020PB/police-brutality/tree/master/tools
 
 # THESE FILES ARE GENERATED - DO NOT EDIT (including this readme)
 
 # THESE FILES ARE GENERATED - DO NOT EDIT (including this readme)
 
-* Please edit the `.md` files on the `master` branch at https://github.com/2020PB/police-brutality
-* Also notice each data row has a `edit_at` link so you can find the source data for every entry.
+* Please edit the `.md` files on the `master` branch at
+  https://github.com/2020PB/police-brutality
+* Also notice each data row has a `edit_at` link so you can find the source
+  data for every entry.
 
 """
 

--- a/tools/data_rewriter.py
+++ b/tools/data_rewriter.py
@@ -4,88 +4,91 @@ import string
 import data_builder
 from data_builder import critical_exit
 
-unknown_location_acronym = 'tbd'
+unknown_location_acronym = "tbd"
 
 # https://gist.github.com/rogerallen/1583593
 us_state_to_abbrev = {
-    'Alabama': 'AL',
-    'Alaska': 'AK',
-    'American Samoa': 'AS',
-    'Arizona': 'AZ',
-    'Arkansas': 'AR',
-    'California': 'CA',
-    'Colorado': 'CO',
-    'Connecticut': 'CT',
-    'Delaware': 'DE',
-    'District of Columbia': 'DC',
-    'Florida': 'FL',
-    'Georgia': 'GA',
-    'Guam': 'GU',
-    'Hawaii': 'HI',
-    'Idaho': 'ID',
-    'Illinois': 'IL',
-    'Indiana': 'IN',
-    'Iowa': 'IA',
-    'Kansas': 'KS',
-    'Kentucky': 'KY',
-    'Louisiana': 'LA',
-    'Maine': 'ME',
-    'Maryland': 'MD',
-    'Massachusetts': 'MA',
-    'Michigan': 'MI',
-    'Minnesota': 'MN',
-    'Mississippi': 'MS',
-    'Missouri': 'MO',
-    'Montana': 'MT',
-    'Nebraska': 'NE',
-    'Nevada': 'NV',
-    'New Hampshire': 'NH',
-    'New Jersey': 'NJ',
-    'New Mexico': 'NM',
-    'New York': 'NY',
-    'North Carolina': 'NC',
-    'North Dakota': 'ND',
-    'Northern Mariana Islands':'MP',
-    'Ohio': 'OH',
-    'Oklahoma': 'OK',
-    'Oregon': 'OR',
-    'Pennsylvania': 'PA',
-    'Puerto Rico': 'PR',
-    'Rhode Island': 'RI',
-    'South Carolina': 'SC',
-    'South Dakota': 'SD',
-    'Tennessee': 'TN',
-    'Texas': 'TX',
-    'Utah': 'UT',
-    'Vermont': 'VT',
-    'Virgin Islands': 'VI',
-    'Virginia': 'VA',
-    'Washington': 'WA',
-    'Washington DC': 'DC',
-    'West Virginia': 'WV',
-    'Wisconsin': 'WI',
-    'Wyoming': 'WY',
-    'Unknown Location': unknown_location_acronym,
+    "Alabama": "AL",
+    "Alaska": "AK",
+    "American Samoa": "AS",
+    "Arizona": "AZ",
+    "Arkansas": "AR",
+    "California": "CA",
+    "Colorado": "CO",
+    "Connecticut": "CT",
+    "Delaware": "DE",
+    "District of Columbia": "DC",
+    "Florida": "FL",
+    "Georgia": "GA",
+    "Guam": "GU",
+    "Hawaii": "HI",
+    "Idaho": "ID",
+    "Illinois": "IL",
+    "Indiana": "IN",
+    "Iowa": "IA",
+    "Kansas": "KS",
+    "Kentucky": "KY",
+    "Louisiana": "LA",
+    "Maine": "ME",
+    "Maryland": "MD",
+    "Massachusetts": "MA",
+    "Michigan": "MI",
+    "Minnesota": "MN",
+    "Mississippi": "MS",
+    "Missouri": "MO",
+    "Montana": "MT",
+    "Nebraska": "NE",
+    "Nevada": "NV",
+    "New Hampshire": "NH",
+    "New Jersey": "NJ",
+    "New Mexico": "NM",
+    "New York": "NY",
+    "North Carolina": "NC",
+    "North Dakota": "ND",
+    "Northern Mariana Islands": "MP",
+    "Ohio": "OH",
+    "Oklahoma": "OK",
+    "Oregon": "OR",
+    "Pennsylvania": "PA",
+    "Puerto Rico": "PR",
+    "Rhode Island": "RI",
+    "South Carolina": "SC",
+    "South Dakota": "SD",
+    "Tennessee": "TN",
+    "Texas": "TX",
+    "Utah": "UT",
+    "Vermont": "VT",
+    "Virgin Islands": "VI",
+    "Virginia": "VA",
+    "Washington": "WA",
+    "Washington DC": "DC",
+    "West Virginia": "WV",
+    "Wisconsin": "WI",
+    "Wyoming": "WY",
+    "Unknown Location": unknown_location_acronym,
 }
 
+
 def random_chars(count):
-    return ''.join(random.choice(string.ascii_lowercase) for _ in range(count))
+    return "".join(random.choice(string.ascii_lowercase) for _ in range(count))
+
 
 def gen_id(row):
-    state = row['state']
+    state = row["state"]
     state_abbrev = us_state_to_abbrev[state].lower()
-    city = row['city']
-    city_abbrev = city.replace(' ', '').replace('.', '').lower()
+    city = row["city"]
+    city_abbrev = city.replace(" ", "").replace(".", "").lower()
     if len(city_abbrev) == 0:
         if state_abbrev == unknown_location_acronym:
             city_abbrev = unknown_location_acronym
-        elif state_abbrev == 'dc':
-            city_abbrev = 'dc'
+        elif state_abbrev == "dc":
+            city_abbrev = "dc"
         else:
             critical_exit("invalid city abbreviation, exiting")
 
     # id_line = f'id: {state_abbrev}-{city_abbrev}-{city_index}'
     return f"{state_abbrev}-{city_abbrev}-{random_chars(4)}"
+
 
 def rewrite_data(data):
     state_to_rows = {}
@@ -94,7 +97,7 @@ def rewrite_data(data):
         if state not in state_to_rows:
             state_to_rows[state] = []
         state_to_rows[state].append(row)
-    
+
     for state, data_rows in state_to_rows.items():
         out_path = f"{data_builder.md_dir}/{state}.md"
         # We don't need to sort `data_rows` because we read these in the order of the markdown files
@@ -102,7 +105,8 @@ def rewrite_data(data):
         with open(out_path, "wb") as fout:
             fout.write(new_md_text.encode("utf-8"))
 
-row_format = '''### {name} | {date_text}
+
+row_format = """### {name} | {date_text}
 
 {description}
 
@@ -114,7 +118,8 @@ id: {id}
 
 {links_md}
 
-'''
+"""
+
 
 def markdown_link(link_obj):
     url = link_obj["url"]
@@ -123,26 +128,30 @@ def markdown_link(link_obj):
         return url
     return f"[{text}]({url})"
 
+
 def gen_md_from_rows(state, rows):
-    city = ''
+    city = ""
     lines = []
     for row in rows:
         if row["city"] and row["city"] != city:
             # new city, let everyone know
             lines.append(f'## {row["city"]}\n')
             city = row["city"]
-        
+
         # convert links list to a links string
-        links_md = '\n'.join('* ' + markdown_link(it) for it in row["links_v2"])
+        links_md = "\n".join(
+            "* " + markdown_link(it) for it in row["links_v2"]
+        )
         row["links_md"] = links_md
 
         # convert tags from a list to a string
-        row["tags_md"] = ', '.join(row["tags"])
+        row["tags_md"] = ", ".join(row["tags"])
 
         # Create this row's markdown
         lines.append(row_format.format(**row))
-    
-    return '\n'.join(lines)
+
+    return "\n".join(lines)
+
 
 def validate_ids_unique(data):
     seen = set()
@@ -153,6 +162,7 @@ def validate_ids_unique(data):
             critical_exit(f"Duplicate id found {row_id}")
         else:
             seen.add(row_id)
+
 
 def add_missing_ids():
     data = data_builder.read_all_data()
@@ -168,7 +178,6 @@ def add_missing_ids():
     validate_ids_unique(data)
 
     rewrite_data(data)
-
 
 
 if __name__ == "__main__":

--- a/tools/data_rewriter.py
+++ b/tools/data_rewriter.py
@@ -100,7 +100,8 @@ def rewrite_data(data):
 
     for state, data_rows in state_to_rows.items():
         out_path = f"{data_builder.md_dir}/{state}.md"
-        # We don't need to sort `data_rows` because we read these in the order of the markdown files
+        # We don't need to sort `data_rows` because we read these in the order
+        # of the markdown files
         new_md_text = gen_md_from_rows(state, data_rows)
         with open(out_path, "wb") as fout:
             fout.write(new_md_text.encode("utf-8"))

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.black]
+line-length = 79
+include = '\.pyi?$'
+exclude = '''
+/(
+    data_build
+    | downloader
+)/
+'''

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,4 +1,6 @@
+black==19.10b0
+flake8==3.8.3
+pytest-cov==2.9.0
+pytest==5.4
 python-dateutil==2.8.1
 six==1.15.0
-pytest==5.4
-pytest-cov==2.9.0

--- a/tools/tests/test_data_builder.py
+++ b/tools/tests/test_data_builder.py
@@ -24,7 +24,8 @@ def test_handle_missing_name(capsys):
 @pytest.mark.skip(reason="failing test, need to handle this case")
 def test_handle_name_with_multiple_pipes():
     malformed_title = "Thing happened | this day | May 30th"
-    result = title_to_name_date(malformed_title)
+    title_to_name_date(malformed_title)
+
     # what should happen here?
 
 
@@ -38,8 +39,8 @@ def test_handle_missing_date(capsys):
 
 def test_handle_weird_date_format(capsys):
     title_with_bad_date = "Title | Leb 21"
+    title_to_name_date(title_with_bad_date)
 
-    result = title_to_name_date(title_with_bad_date)
     captured = capsys.readouterr()
     assert "Failed date format parse for title" in str(captured)
 
@@ -47,6 +48,6 @@ def test_handle_weird_date_format(capsys):
 @pytest.mark.skip(reason="failing test, need to handle this case")
 def test_handle_nonexistant_date():
     title_with_bad_date = "Title | February 31st"
+    title_to_name_date(title_with_bad_date)
 
-    result = title_to_name_date(title_with_bad_date)
     # what should happen here?

--- a/tools/tests/test_data_builder.py
+++ b/tools/tests/test_data_builder.py
@@ -3,14 +3,8 @@ import pytest
 from data_builder import title_to_name_date
 
 tests = [
-    (
-        'Title here | May 30th',
-        ('Title here', '2020-05-30', 'May 30th')
-    ),
-    (
-        'Title here',
-        ('Title here', '', '')
-    ),
+    ("Title here | May 30th", ("Title here", "2020-05-30", "May 30th")),
+    ("Title here", ("Title here", "", "")),
 ]
 
 
@@ -20,22 +14,22 @@ def test_title_to_name_date(input, expected):
 
 
 def test_handle_missing_name(capsys):
-    title_missing_name = '| May 30th'
+    title_missing_name = "| May 30th"
     title_to_name_date(title_missing_name)
 
     captured = capsys.readouterr()
-    assert "Failed name parse: missing name for" in str(captured) 
+    assert "Failed name parse: missing name for" in str(captured)
 
 
 @pytest.mark.skip(reason="failing test, need to handle this case")
 def test_handle_name_with_multiple_pipes():
-    malformed_title = 'Thing happened | this day | May 30th'
+    malformed_title = "Thing happened | this day | May 30th"
     result = title_to_name_date(malformed_title)
     # what should happen here?
 
 
 def test_handle_missing_date(capsys):
-    title_missing_date = 'Title thinger'
+    title_missing_date = "Title thinger"
     title_to_name_date(title_missing_date)
 
     captured = capsys.readouterr()
@@ -43,7 +37,7 @@ def test_handle_missing_date(capsys):
 
 
 def test_handle_weird_date_format(capsys):
-    title_with_bad_date = 'Title | Leb 21'
+    title_with_bad_date = "Title | Leb 21"
 
     result = title_to_name_date(title_with_bad_date)
     captured = capsys.readouterr()
@@ -52,7 +46,7 @@ def test_handle_weird_date_format(capsys):
 
 @pytest.mark.skip(reason="failing test, need to handle this case")
 def test_handle_nonexistant_date():
-    title_with_bad_date = 'Title | February 31st'
+    title_with_bad_date = "Title | February 31st"
 
     result = title_to_name_date(title_with_bad_date)
     # what should happen here?

--- a/tools/tests/test_process_md_texts.py
+++ b/tools/tests/test_process_md_texts.py
@@ -4,23 +4,29 @@ from data_builder import process_md_texts
 
 
 def test_handle_dc():
-    data = {'Washington DC': "### Title | June 1st\n\nDescription of things \n\n**Links**\n\n* https://twitter.com/"}
+    data = {
+        "Washington DC": "### Title | June 1st\n\nDescription of things \n\n**Links**\n\n* https://twitter.com/"
+    }
     result = process_md_texts(data)
 
-    assert result[0]['city'] == 'DC'
+    assert result[0]["city"] == "DC"
 
 
 def test_handle_missing_location():
-    data = {'Unknown Location': "### Title | June 1st\n\nDescription of things \n\n**Links**\n\n* https://twitter.com/"}
+    data = {
+        "Unknown Location": "### Title | June 1st\n\nDescription of things \n\n**Links**\n\n* https://twitter.com/"
+    }
     result = process_md_texts(data)
 
-    assert result[0]['city'] == ''
+    assert result[0]["city"] == ""
 
 
 def test_handle_missing_links(capsys):
-    data = {'Washington DC': "### Title | June 1st\n\nDescription of things \n\n**Links**\n\n\n\n### Another Title | May 31\n\nDescription.\n\n**Links**\n\n"}
+    data = {
+        "Washington DC": "### Title | June 1st\n\nDescription of things \n\n**Links**\n\n\n\n### Another Title | May 31\n\nDescription.\n\n**Links**\n\n"
+    }
     process_md_texts(data)
-    
+
     captured = capsys.readouterr()
     assert "Failed links parse: missing links for" in str(captured)
 

--- a/tools/tests/test_process_md_texts.py
+++ b/tools/tests/test_process_md_texts.py
@@ -1,11 +1,14 @@
-import pytest
-
 from data_builder import process_md_texts
 
 
 def test_handle_dc():
     data = {
-        "Washington DC": "### Title | June 1st\n\nDescription of things \n\n**Links**\n\n* https://twitter.com/"
+        "Washington DC": (
+            "### Title | June 1st\n\n"
+            "Description of things\n\n"
+            "**Links**\n\n"
+            "* https://twitter.com/"
+        )
     }
     result = process_md_texts(data)
 
@@ -14,7 +17,12 @@ def test_handle_dc():
 
 def test_handle_missing_location():
     data = {
-        "Unknown Location": "### Title | June 1st\n\nDescription of things \n\n**Links**\n\n* https://twitter.com/"
+        "Unknown Location": (
+            "### Title | June 1st\n\n"
+            "Description of things\n\n"
+            "**Links**"
+            "\n\n* https://twitter.com/"
+        )
     }
     result = process_md_texts(data)
 
@@ -23,7 +31,15 @@ def test_handle_missing_location():
 
 def test_handle_missing_links(capsys):
     data = {
-        "Washington DC": "### Title | June 1st\n\nDescription of things \n\n**Links**\n\n\n\n### Another Title | May 31\n\nDescription.\n\n**Links**\n\n"
+        "Washington DC": (
+            "### Title | June 1st\n\n"
+            "Description of things\n\n"
+            "**Links**\n\n"
+            "\n\n"
+            "### Another Title | May 31\n\n"
+            "Description.\n\n"
+            "**Links**\n\n"
+        )
     }
     process_md_texts(data)
 


### PR DESCRIPTION
Added Black and Flake8 including workflow and updated `tools/README.md`:
- [psf/black](https://github.com/psf/black): The uncompromising Python code formatter
- [Flake8](https://flake8.pycqa.org/en/latest/): Your Tool For Style Guide Enforcement

Unit tests passed on my laptop:
```
=============================== test session starts ================================
platform darwin -- Python 3.8.5, pytest-5.4.0, py-1.9.0, pluggy-0.13.1 -- [...]
cachedir: .pytest_cache
rootdir: [...]/police-brutality/tools
plugins: cov-2.9.0
collected 11 items                                                                 

tests/test_data_builder.py::test_title_to_name_date[Title here | May 30th-expected0] PASSED [  9%]
tests/test_data_builder.py::test_title_to_name_date[Title here-expected1] PASSED [ 18%]
tests/test_data_builder.py::test_handle_missing_name PASSED                  [ 27%]
tests/test_data_builder.py::test_handle_name_with_multiple_pipes SKIPPED     [ 36%]
tests/test_data_builder.py::test_handle_missing_date PASSED                  [ 45%]
tests/test_data_builder.py::test_handle_weird_date_format PASSED             [ 54%]
tests/test_data_builder.py::test_handle_nonexistant_date SKIPPED             [ 63%]
tests/test_process_md_texts.py::test_handle_dc PASSED                        [ 72%]
tests/test_process_md_texts.py::test_handle_missing_location PASSED          [ 81%]
tests/test_process_md_texts.py::test_handle_missing_links PASSED             [ 90%]
tests/test_process_md_texts.py::test_more_than_200_records_found PASSED      [100%]

=========================== 9 passed, 2 skipped in 0.07s ===========================
```