### PR TITLE
Add "Not Actively Maintained" to raw video link

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ As these protests have continued, hundreds of incidents have been recorded where
 * [Frequently Asked Questions](./CONTRIBUTING.md#Frequently-Asked-Questions)
 * [Building with the API](./docs/building-with-the-api.md)
 * [IPFS Archive](https://gateway.temporal.cloud/ipns/2020pb-archive.temporal.cloud)
+* [Raw Video Archive (not actively maintained)](https://github.com/pb-files/pb-videos)
 * **Incident Reports**
   * [Alabama](./reports/Alabama.md)
   * [Arizona](./reports/Arizona.md)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ As these protests have continued, hundreds of incidents have been recorded where
 * [Contribution Guidelines](./CONTRIBUTING.md)
 * [Frequently Asked Questions](./CONTRIBUTING.md#Frequently-Asked-Questions)
 * [Building with the API](./docs/building-with-the-api.md)
-* [Raw Video Archive](https://github.com/pb-files/pb-videos)
 * [IPFS Archive](https://gateway.temporal.cloud/ipns/2020pb-archive.temporal.cloud)
 * **Incident Reports**
   * [Alabama](./reports/Alabama.md)


### PR DESCRIPTION
That link leads to resources which haven't been updated in 2 months. Unless there are plans to update those resources, we should probably just remove that link from the README.