### PR TITLE
complete the two skipped incomplete tests

### DIFF
--- a/tools/tests/test_data_builder.py
+++ b/tools/tests/test_data_builder.py
@@ -27,11 +27,16 @@ def test_handle_missing_name(capsys):
     assert "Failed name parse: missing name for" in str(captured) 
 
 
-@pytest.mark.skip(reason="failing test, need to handle this case")
-def test_handle_name_with_multiple_pipes():
+def test_handle_name_with_multiple_pipes(capsys):
     malformed_title = 'Thing happened | this day | May 30th'
-    result = title_to_name_date(malformed_title)
-    # what should happen here?
+    title_to_name_date(malformed_title)
+
+    captured = capsys.readouterr()
+    assert (
+        "Failed date format parse for title 'Thing happened'"
+        " and date 'this day': 'NoneType' object has no attribute 'group'"
+        in str(captured)
+    )
 
 
 def test_handle_missing_date(capsys):
@@ -50,9 +55,12 @@ def test_handle_weird_date_format(capsys):
     assert "Failed date format parse for title" in str(captured)
 
 
-@pytest.mark.skip(reason="failing test, need to handle this case")
-def test_handle_nonexistant_date():
+def test_handle_nonexistant_date(capsys):
     title_with_bad_date = 'Title | February 31st'
+    title_to_name_date(title_with_bad_date)
 
-    result = title_to_name_date(title_with_bad_date)
-    # what should happen here?
+    captured = capsys.readouterr()
+    assert (
+        "Failed date format parse for title 'Title' and date 'February 31st':"
+        " day is out of range for month: February 31" in str(captured)
+    )


### PR DESCRIPTION
## Overview
Tests now pass 100% (none are skipped)

## With this PR
Local run:
```
=============================== test session starts ================================
platform darwin -- Python 3.8.5, pytest-5.4.0, py-1.9.0, pluggy-0.13.1 -- [...]
cachedir: .pytest_cache
rootdir: [...]/police-brutality/tools
plugins: cov-2.9.0
collected 11 items                                                                 

tests/test_data_builder.py::test_title_to_name_date[Title here | May 30th-expected0] PASSED [  9%]
tests/test_data_builder.py::test_title_to_name_date[Title here-expected1] PASSED [ 18%]
tests/test_data_builder.py::test_handle_missing_name PASSED                  [ 27%]
tests/test_data_builder.py::test_handle_name_with_multiple_pipes PASSED      [ 36%]
tests/test_data_builder.py::test_handle_missing_date PASSED                  [ 45%]
tests/test_data_builder.py::test_handle_weird_date_format PASSED             [ 54%]
tests/test_data_builder.py::test_handle_nonexistant_date PASSED              [ 63%]
tests/test_process_md_texts.py::test_handle_dc PASSED                        [ 72%]
tests/test_process_md_texts.py::test_handle_missing_location PASSED          [ 81%]
tests/test_process_md_texts.py::test_handle_missing_links PASSED             [ 90%]
tests/test_process_md_texts.py::test_more_than_200_records_found PASSED      [100%]

================================ 11 passed in 0.07s ================================
```

## Before/without this PR
Local run:
```
=============================== test session starts ================================
platform darwin -- Python 3.8.5, pytest-5.4.0, py-1.9.0, pluggy-0.13.1 -- [...]
cachedir: .pytest_cache
rootdir: [...]/police-brutality/tools
rootdir: /Users/tim/TimidRobot/git/police-brutality/tools
plugins: cov-2.9.0
collected 11 items                                                                 

tests/test_data_builder.py::test_title_to_name_date[Title here | May 30th-expected0] PASSED [  9%]
tests/test_data_builder.py::test_title_to_name_date[Title here-expected1] PASSED [ 18%]
tests/test_data_builder.py::test_handle_missing_name PASSED                  [ 27%]
tests/test_data_builder.py::test_handle_name_with_multiple_pipes SKIPPED     [ 36%]
tests/test_data_builder.py::test_handle_missing_date PASSED                  [ 45%]
tests/test_data_builder.py::test_handle_weird_date_format PASSED             [ 54%]
tests/test_data_builder.py::test_handle_nonexistant_date SKIPPED             [ 63%]
tests/test_process_md_texts.py::test_handle_dc PASSED                        [ 72%]
tests/test_process_md_texts.py::test_handle_missing_location PASSED          [ 81%]
tests/test_process_md_texts.py::test_handle_missing_links PASSED             [ 90%]
tests/test_process_md_texts.py::test_more_than_200_records_found PASSED      [100%]

=========================== 9 passed, 2 skipped in 0.07s ===========================
```